### PR TITLE
Add copy command

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
@@ -233,4 +234,30 @@ func (c *snapshotterOptions) validate() error {
 // complete completes the config.
 func (c *snapshotterOptions) complete() {
 	c.snapstoreConfig.Complete()
+}
+
+type copierOptions struct {
+	copierConfig    *copier.Config
+	snapstoreConfig *snapstore.Config
+}
+
+func newCopierOptions() *copierOptions {
+	return &copierOptions{
+		copierConfig:    copier.NewConfig(),
+		snapstoreConfig: snapstore.NewSnapstoreConfig(),
+	}
+}
+
+func (c *copierOptions) addFlags(fs *flag.FlagSet) {
+	c.copierConfig.AddFlags(fs)
+	c.snapstoreConfig.AddFlags(fs)
+}
+
+func (c *copierOptions) validate() error {
+	return c.copierConfig.Validate()
+}
+
+func (c *copierOptions) complete() {
+	c.snapstoreConfig.Complete()
+	c.copierConfig.CompleteWithSnapstoreConfig(c.snapstoreConfig)
 }

--- a/pkg/snapshot/copier/copier.go
+++ b/pkg/snapshot/copier/copier.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier
+
+import (
+	"fmt"
+
+	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewCopier returns a new copier
+func NewCopier(config *Config, snapstoreConfig *snapstore.Config, logger *logrus.Entry) *Copier {
+	return &Copier{
+		logger:                logger.WithField("actor", "snapshotter"),
+		sourceSnapstoreConfig: config.SourceSnapstore,
+		snapstoreConfig:       snapstoreConfig,
+	}
+}
+
+// Run runs the copy command
+func (c *Copier) Run() error {
+	source, err := snapstore.GetSnapstore(c.sourceSnapstoreConfig)
+	if err != nil {
+		return fmt.Errorf("Failed to get source snapstore: %v", err)
+	}
+
+	destination, err := snapstore.GetSnapstore(c.snapstoreConfig)
+	if err != nil {
+		return fmt.Errorf("Failed to get source snapstore: %v", err)
+	}
+
+	backups, err := miscellaneous.GetAllBackups(source)
+	if err != nil {
+		return fmt.Errorf("failed to get latest snapshot: %v", err)
+	}
+	if backups == nil {
+		return fmt.Errorf("No snapshot found. Will do nothing.")
+	}
+
+	for _, backup := range backups {
+		rc, err := source.Fetch(*backup.FullSnapshot)
+		if err != nil {
+			return fmt.Errorf("failed to get readerCloser form baseSnapshot")
+		}
+
+		if err := destination.Save(*backup.FullSnapshot, rc); err != nil {
+			return fmt.Errorf("failed to save snapshot to destination")
+		}
+
+		for _, deltaSnap := range backup.DeltaSnapshotList {
+			rc, err := source.Fetch(*deltaSnap)
+			if err != nil {
+				return fmt.Errorf("failed to get readerCloser form baseSnapshot")
+			}
+
+			if err := destination.Save(*deltaSnap, rc); err != nil {
+				return fmt.Errorf("failed to save snapshot to destination")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/snapshot/copier/init.go
+++ b/pkg/snapshot/copier/init.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier
+
+import (
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+	flag "github.com/spf13/pflag"
+)
+
+// NewConfig returns the copier config.
+func NewConfig() *Config {
+	sourceSnapstoreConfig := snapstore.NewSnapstoreConfig()
+	sourceSnapstoreConfig.IsSource = true
+	return &Config{
+		SourceSnapstore: sourceSnapstoreConfig,
+	}
+}
+
+// AddFlags adds the flags to flagset.
+func (c *Config) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&c.SourceSnapstore.Provider, "source-storage-provider", c.SourceSnapstore.Provider, "source snapshot storage provider")
+	fs.StringVar(&c.SourceSnapstore.Container, "source-store-container", c.SourceSnapstore.Container, "source container which will be used as snapstore")
+	fs.StringVar(&c.SourceSnapstore.Prefix, "source-store-prefix", c.SourceSnapstore.Prefix, "source prefix or directory inside container under which snapstore is created")
+}
+
+// Validate validates the config.
+func (c *Config) Validate() error {
+	return nil
+}
+
+// Complete completes the config.
+func (c *Config) CompleteWithSnapstoreConfig(other *snapstore.Config) {
+	c.SourceSnapstore.CompleteWithOther(other)
+}

--- a/pkg/snapshot/copier/types.go
+++ b/pkg/snapshot/copier/types.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier
+
+import (
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Copier can be used to copy backups
+type Copier struct {
+	logger                *logrus.Entry
+	sourceSnapstoreConfig *snapstore.Config
+	snapstoreConfig       *snapstore.Config
+}
+
+// Config holds the configuration for the copier
+type Config struct {
+	SourceSnapstore *snapstore.Config `json:"sourceSnapstore,omitempty"`
+}

--- a/pkg/snapstore/init.go
+++ b/pkg/snapstore/init.go
@@ -54,3 +54,17 @@ func (c *Config) Validate() error {
 func (c *Config) Complete() {
 	c.Prefix = path.Join(c.Prefix, backupFormatVersion)
 }
+
+// CompleteWithOther completes the config based on other config
+func (c *Config) CompleteWithOther(other *Config) {
+	if c.Provider == "" {
+		c.Provider = other.Provider
+	}
+	if c.Prefix == "" {
+		c.Prefix = other.Prefix
+	} else {
+		c.Prefix = path.Join(c.Prefix, backupFormatVersion)
+	}
+	c.MaxParallelChunkUploads = other.MaxParallelChunkUploads
+	c.TempDir = other.TempDir
+}

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -108,6 +108,8 @@ type Config struct {
 	MaxParallelChunkUploads uint `json:"maxParallelChunkUploads,omitempty"`
 	// Temporary Directory
 	TempDir string `json:"tempDir,omitempty"`
+	// IsSource determines if this SnapStore is the source for a copy operation
+	IsSource bool `json:"isSource,omitempty"`
 }
 
 type chunk struct {

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -25,14 +25,19 @@ import (
 )
 
 const (
-	envStorageContainer = "STORAGE_CONTAINER"
-	defaultLocalStore   = "default.bkp"
+	envStorageContainer       = "STORAGE_CONTAINER"
+	sourceEnvStorageContainer = "SOURCE_STORAGE_CONTAINER"
+	defaultLocalStore         = "default.bkp"
 )
 
 // GetSnapstore returns the snapstore object for give storageProvider with specified container
 func GetSnapstore(config *Config) (SnapStore, error) {
 	if config.Container == "" {
-		config.Container = os.Getenv(envStorageContainer)
+		if config.IsSource {
+			config.Container = os.Getenv(sourceEnvStorageContainer)
+		} else {
+			config.Container = os.Getenv(envStorageContainer)
+		}
 	}
 
 	if len(config.TempDir) == 0 {
@@ -72,7 +77,7 @@ func GetSnapstore(config *Config) (SnapStore, error) {
 		if config.Container == "" {
 			return nil, fmt.Errorf("storage container name not specified")
 		}
-		return NewGCSSnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads)
+		return NewGCSSnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, config.IsSource)
 	case SnapstoreProviderSwift:
 		if config.Container == "" {
 			return nil, fmt.Errorf("storage container name not specified")


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a simple copy command that takes in a source and destination backup containers and copies snapshots between them.
Part of https://github.com/gardener/gardener/issues/3875

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
