### PR TITLE
Adds the option to copy backups to the server command

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -38,8 +38,12 @@ func NewCopyCommand(ctx context.Context) *cobra.Command {
 			}
 			opts.complete()
 
-			copier := copier.NewCopier(opts.copierConfig, opts.snapstoreConfig, logger)
+			destStorage, sourceStorage, err := copier.GetSourceAndDestinationStores(opts.copierConfig, opts.snapstoreConfig)
+			if err != nil {
+				logger.Fatalf("Could not get source and destination snapstores: %v", err)
+			}
 
+			copier := copier.NewCopier(destStorage, sourceStorage, logger)
 			if err := copier.Run(); err != nil {
 				logger.Fatalf("Copy operation failed: %v", err)
 				return

--- a/pkg/objectstore/types.go
+++ b/pkg/objectstore/types.go
@@ -48,6 +48,7 @@ type OperationStatus string
 const (
 	OperationStatusInitial OperationStatus = "Initial"
 	OperationStatusReady   OperationStatus = "Ready"
+	OperationStatusDone    OperationStatus = "Done"
 )
 
 type CopyOperation struct {

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
@@ -34,6 +35,7 @@ func NewBackupRestoreComponentConfig() *BackupRestoreComponentConfig {
 		EtcdConnectionConfig:    etcdutil.NewEtcdConnectionConfig(),
 		ServerConfig:            NewHTTPServerConfig(),
 		SnapshotterConfig:       snapshotter.NewSnapshotterConfig(),
+		CopierConfig:            copier.NewConfig(),
 		SnapstoreConfig:         snapstore.NewSnapstoreConfig(),
 		RestorationConfig:       restorer.NewRestorationConfig(),
 		CompressionConfig:       compressor.NewCompressorConfig(),
@@ -46,12 +48,14 @@ func (c *BackupRestoreComponentConfig) AddFlags(fs *flag.FlagSet) {
 	c.EtcdConnectionConfig.AddFlags(fs)
 	c.ServerConfig.AddFlags(fs)
 	c.SnapshotterConfig.AddFlags(fs)
+	c.CopierConfig.AddFlags(fs)
 	c.SnapstoreConfig.AddFlags(fs)
 	c.RestorationConfig.AddFlags(fs)
 	c.CompressionConfig.AddFlags(fs)
 
 	// Miscellaneous
 	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "schedule to defragment etcd data directory")
+	fs.BoolVar(&c.CopyBackups, "copy-backups", c.CopyBackups, "Determines whether etcd backups should be copied")
 }
 
 // Validate validates the config.
@@ -83,6 +87,7 @@ func (c *BackupRestoreComponentConfig) Validate() error {
 // Complete completes the config.
 func (c *BackupRestoreComponentConfig) Complete() {
 	c.SnapstoreConfig.Complete()
+	c.CopierConfig.CompleteWithSnapstoreConfig(c.SnapstoreConfig)
 }
 
 // HTTPServerConfig holds the server config.

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -17,6 +17,7 @@ package server
 import (
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
@@ -32,10 +33,12 @@ type BackupRestoreComponentConfig struct {
 	EtcdConnectionConfig    *etcdutil.EtcdConnectionConfig `json:"etcdConnectionConfig,omitempty"`
 	ServerConfig            *HTTPServerConfig              `json:"serverConfig,omitempty"`
 	SnapshotterConfig       *snapshotter.Config            `json:"snapshotterConfig,omitempty"`
+	CopierConfig            *copier.Config                 `json:"copierConfig,omitempty"`
 	SnapstoreConfig         *snapstore.Config              `json:"snapstoreConfig,omitempty"`
 	RestorationConfig       *restorer.RestorationConfig    `json:"restorationConfig,omitempty"`
 	CompressionConfig       *compressor.CompressionConfig  `json:"compressionConfig,omitempty"`
 	DefragmentationSchedule string                         `json:"defragmentationSchedule"`
+	CopyBackups             bool                           `json:"copyBackups"`
 }
 
 // latestSnapshotMetadata holds snapshot details of latest full and delta snapshots

--- a/pkg/snapshot/copier/types.go
+++ b/pkg/snapshot/copier/types.go
@@ -22,9 +22,9 @@ import (
 
 // Copier can be used to copy backups
 type Copier struct {
-	logger                *logrus.Entry
-	sourceSnapstoreConfig *snapstore.Config
-	snapstoreConfig       *snapstore.Config
+	logger          *logrus.Entry
+	sourceSnapStore snapstore.SnapStore
+	snapStore       snapstore.SnapStore
 }
 
 // Config holds the configuration for the copier


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `--copy-backups` option to the `etcd-backup-restore server` command which will initiate a CopyOperation and copy the backups once the CopyOperation has status Ready.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3875

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
