### PR TITLE
Wait instead of shutting down after copy operation is Ready

### DIFF
--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -226,9 +226,8 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 		if copyOp != nil {
 			if copyOp.Source {
 				b.logger.Infof("Copy operation with owner %s and status %s initiated at %s as source", copyOp.Owner, copyOp.Status, copyOp.Initiated)
+				handler.SetStatus(http.StatusServiceUnavailable)
 				if copyOp.Status == objectstore.OperationStatusInitial {
-					handler.SetStatus(http.StatusServiceUnavailable)
-
 					// Take the final full snapshot
 					b.logger.Infof("Taking final full snapshot...")
 					if _, err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
@@ -244,14 +243,12 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 						continue
 					}
 				}
-				b.logger.Infof("Shutting down...")
-				return
 			} else {
 				b.logger.Infof("Copy operation with owner %s and status %s initiated at %s as destination", copyOp.Owner, copyOp.Status, copyOp.Initiated)
-				b.logger.Infof("Sleeping for 30 seconds...")
-				time.Sleep(30 * time.Second)
-				continue
 			}
+			b.logger.Infof("Sleeping for 30 seconds...")
+			time.Sleep(30 * time.Second)
+			continue
 		}
 
 		// The decision to either take an initial delta snapshot or


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures that the `backuprestoreserver` waits instead of shutting down after a copy operation is `Ready`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
