### PR TITLE
Refactor etcd killing and cleanup unused CopyOperation fields

### DIFF
--- a/pkg/objectstore/types.go
+++ b/pkg/objectstore/types.go
@@ -52,8 +52,5 @@ const (
 )
 
 type CopyOperation struct {
-	Source    bool            `json:"source"`
-	Owner     string          `json:"owner"`
-	Initiated time.Time       `json:"initiated"`
-	Status    OperationStatus `json:"status"`
+	Status OperationStatus `json:"status"`
 }

--- a/pkg/snapshot/copier/copier.go
+++ b/pkg/snapshot/copier/copier.go
@@ -150,9 +150,6 @@ func WaitForCopyOperationReady(timer *time.Timer, os objectstore.ObjectStore) (*
 func InitializeCopyOperation() (*objectstore.Object, *objectstore.CopyOperation) {
 	now := time.Now().UTC()
 	copyOp := &objectstore.CopyOperation{
-		Source:    true,
-		Owner:     "foo",
-		Initiated: now,
 		Status:    objectstore.OperationStatusInitial,
 	}
 	obj := &objectstore.Object{

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -25,17 +25,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	cron "github.com/robfig/cron/v3"
+	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/clientv3"
+
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/errors"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/metrics"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
-	"github.com/gardener/etcd-backup-restore/pkg/objectstore"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
-	"github.com/prometheus/client_golang/prometheus"
-	cron "github.com/robfig/cron/v3"
-	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/clientv3"
 )
 
 // NewSnapshotter returns the snapshotter object.
@@ -578,26 +578,3 @@ func (ssr *Snapshotter) resetFullSnapshotTimer() error {
 	return nil
 }
 
-// TODO Testing only, remove
-func (ssr *Snapshotter) writeCopyOperation(source bool) error {
-	os := objectstore.NewObjectStore(ssr.store, ssr.logger)
-
-	now := time.Now()
-	obj := &objectstore.Object{
-		Kind:      objectstore.ObjectKindCopyOperation,
-		Name:      "test",
-		CreatedOn: now,
-	}
-	copyOp := &objectstore.CopyOperation{
-		Source:    source,
-		Owner:     "foo",
-		Initiated: now,
-		Status:    objectstore.OperationStatusInitial,
-	}
-	ssr.logger.Infof("Writing object %v with contents %v...", obj, copyOp)
-	if err := os.Write(obj, copyOp); err != nil {
-		return err
-	}
-
-	return nil
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
* Etcd is now killed always after the snapshotter is stopped, no matter the reason
* Unused `CopyOperation` fields have been removed
* Obsolete test code have been removed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

