### PR TITLE
Add blockers to simulate broker connection to the backup container

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v0.12.0-dev
+v0.12.0-dev-cpm-poc

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -38,8 +38,12 @@ func NewCopyCommand(ctx context.Context) *cobra.Command {
 			}
 			opts.complete()
 
-			copier := copier.NewCopier(opts.copierConfig, opts.snapstoreConfig, logger)
+			destStorage, sourceStorage, err := copier.GetSourceAndDestinationStores(opts.copierConfig, opts.snapstoreConfig)
+			if err != nil {
+				logger.Fatalf("Could not get source and destination snapstores: %v", err)
+			}
 
+			copier := copier.NewCopier(destStorage, sourceStorage, logger)
 			if err := copier.Run(); err != nil {
 				logger.Fatalf("Copy operation failed: %v", err)
 				return

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
@@ -233,4 +234,30 @@ func (c *snapshotterOptions) validate() error {
 // complete completes the config.
 func (c *snapshotterOptions) complete() {
 	c.snapstoreConfig.Complete()
+}
+
+type copierOptions struct {
+	copierConfig    *copier.Config
+	snapstoreConfig *snapstore.Config
+}
+
+func newCopierOptions() *copierOptions {
+	return &copierOptions{
+		copierConfig:    copier.NewConfig(),
+		snapstoreConfig: snapstore.NewSnapstoreConfig(),
+	}
+}
+
+func (c *copierOptions) addFlags(fs *flag.FlagSet) {
+	c.copierConfig.AddFlags(fs)
+	c.snapstoreConfig.AddFlags(fs)
+}
+
+func (c *copierOptions) validate() error {
+	return c.copierConfig.Validate()
+}
+
+func (c *copierOptions) complete() {
+	c.snapstoreConfig.Complete()
+	c.copierConfig.CompleteWithSnapstoreConfig(c.snapstoreConfig)
 }

--- a/pkg/miscellaneous/miscellaneous.go
+++ b/pkg/miscellaneous/miscellaneous.go
@@ -34,7 +34,7 @@ func GetLatestFullSnapshotAndDeltaSnapList(store snapstore.SnapStore) (*snapstor
 	}
 
 	for index := len(snapList); index > 0; index-- {
-		if snapList[index-1].IsChunk {
+		if snapList[index-1].IsChunk || snapList[index-1].Kind == snapstore.SnapshotKindObject {
 			continue
 		}
 		if snapList[index-1].Kind == snapstore.SnapshotKindFull {

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/gardener/etcd-backup-restore/pkg/errors"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+)
+
+type objectStore struct {
+	store  snapstore.SnapStore
+	logger *logrus.Entry
+}
+
+func NewObjectStore(store snapstore.SnapStore, logger *logrus.Entry) ObjectStore {
+	return &objectStore{
+		store:  store,
+		logger: logger,
+	}
+}
+
+// List lists all objects in the store.
+func (os *objectStore) List() (ObjectList, error) {
+	snapList, err := os.store.List()
+	if err != nil {
+		return nil, &errors.SnapstoreError{
+			Message: fmt.Sprintf("could not list snapshots in snapstore: %v", err),
+		}
+	}
+
+	var objects ObjectList
+	for _, s := range snapList {
+		if s.Kind == snapstore.SnapshotKindObject && !s.IsChunk {
+			tokens := strings.Split(s.SnapName, "-")
+			if len(tokens) != 4 {
+				return nil, fmt.Errorf("invalid object snapshot name: %s", s.SnapName)
+			}
+
+			objects = append(objects, &Object{
+				Kind:      ObjectKind(tokens[1]),
+				Name:      tokens[2],
+				CreatedOn: s.CreatedOn,
+			})
+		}
+	}
+
+	return objects, nil
+}
+
+// Read reads the given object from the store.
+func (os *objectStore) Read(obj *Object, v interface{}) error {
+	s := snapstore.NewObjectSnapshot(string(obj.Kind), obj.Name, obj.CreatedOn)
+	rc, err := os.store.Fetch(*s)
+	if err != nil {
+		return &errors.SnapstoreError{
+			Message: fmt.Sprintf("could not fetch object snapshot from snapstore: %v", err),
+		}
+	}
+	defer rc.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(rc); err != nil {
+		return &errors.SnapstoreError{
+			Message: fmt.Sprintf("could not read object from snapstore: %v", err),
+		}
+	}
+
+	if err := json.Unmarshal(buf.Bytes(), v); err != nil {
+		return fmt.Errorf("could not unmarshal object from json: %w", err)
+	}
+
+	return nil
+}
+
+// Write writes the given object to the store.
+func (os *objectStore) Write(obj *Object, v interface{}) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("could not marshal object to json: %w", err)
+	}
+
+	rc := ioutil.NopCloser(bytes.NewReader(b))
+	defer rc.Close()
+
+	s := snapstore.NewObjectSnapshot(string(obj.Kind), obj.Name, obj.CreatedOn)
+	if err := os.store.Save(*s, rc); err != nil {
+		return &errors.SnapstoreError{
+			Message: fmt.Sprintf("could not save object snapshot to snapstore: %v", err),
+		}
+	}
+
+	return nil
+}
+
+// Delete deletes the given object from the store.
+func (os *objectStore) Delete(obj *Object) error {
+	s := snapstore.NewObjectSnapshot(string(obj.Kind), obj.Name, obj.CreatedOn)
+	if err := os.store.Delete(*s); err != nil {
+		return &errors.SnapstoreError{
+			Message: fmt.Sprintf("could not delete object snapshot from snapstore: %v", err),
+		}
+	}
+
+	return nil
+}

--- a/pkg/objectstore/types.go
+++ b/pkg/objectstore/types.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore
+
+import (
+	"time"
+)
+
+type ObjectStore interface {
+	// List lists all objects in the store.
+	List() (ObjectList, error)
+	// Read reads the given object from the store.
+	Read(*Object, interface{}) error
+	// Write writes the given object to the store.
+	Write(*Object, interface{}) error
+	// Delete deletes the given object from the store.
+	Delete(*Object) error
+}
+
+type ObjectKind string
+
+const (
+	ObjectKindCopyOperation ObjectKind = "CopyOperation"
+)
+
+type Object struct {
+	Kind      ObjectKind `json:"kind"`
+	Name      string     `json:"name"`
+	CreatedOn time.Time  `json:"createdOn"`
+}
+
+type ObjectList []*Object
+
+type OperationStatus string
+
+const (
+	OperationStatusInitiated  OperationStatus = "Initiated"
+	OperationStatusInProgress OperationStatus = "InProgress"
+	OperationStatusFinished   OperationStatus = "Finished"
+)
+
+type CopyOperation struct {
+	Source    bool            `json:"source"`
+	Owner     string          `json:"owner"`
+	Initiated time.Time       `json:"initiated"`
+	Status    OperationStatus `json:"status"`
+}

--- a/pkg/objectstore/types.go
+++ b/pkg/objectstore/types.go
@@ -52,8 +52,5 @@ const (
 )
 
 type CopyOperation struct {
-	Source    bool            `json:"source"`
-	Owner     string          `json:"owner"`
-	Initiated time.Time       `json:"initiated"`
-	Status    OperationStatus `json:"status"`
+	Status OperationStatus `json:"status"`
 }

--- a/pkg/objectstore/types.go
+++ b/pkg/objectstore/types.go
@@ -48,6 +48,7 @@ type OperationStatus string
 const (
 	OperationStatusInitial OperationStatus = "Initial"
 	OperationStatusReady   OperationStatus = "Ready"
+	OperationStatusDone    OperationStatus = "Done"
 )
 
 type CopyOperation struct {

--- a/pkg/objectstore/types.go
+++ b/pkg/objectstore/types.go
@@ -46,9 +46,8 @@ type ObjectList []*Object
 type OperationStatus string
 
 const (
-	OperationStatusInitiated  OperationStatus = "Initiated"
-	OperationStatusInProgress OperationStatus = "InProgress"
-	OperationStatusFinished   OperationStatus = "Finished"
+	OperationStatusInitial OperationStatus = "Initial"
+	OperationStatusReady   OperationStatus = "Ready"
 )
 
 type CopyOperation struct {

--- a/pkg/objectstore/types.go
+++ b/pkg/objectstore/types.go
@@ -33,6 +33,7 @@ type ObjectKind string
 
 const (
 	ObjectKindCopyOperation ObjectKind = "CopyOperation"
+	ObjectKindBlocker       ObjectKind = "Blocker"
 )
 
 type Object struct {
@@ -54,3 +55,5 @@ const (
 type CopyOperation struct {
 	Status OperationStatus `json:"status"`
 }
+
+type Blocker struct{}

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -226,9 +226,8 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 		if copyOp != nil {
 			if copyOp.Source {
 				b.logger.Infof("Copy operation with owner %s and status %s initiated at %s as source", copyOp.Owner, copyOp.Status, copyOp.Initiated)
+				handler.SetStatus(http.StatusServiceUnavailable)
 				if copyOp.Status == objectstore.OperationStatusInitial {
-					handler.SetStatus(http.StatusServiceUnavailable)
-
 					// Take the final full snapshot
 					b.logger.Infof("Taking final full snapshot...")
 					if _, err := ssr.TakeFullSnapshotAndResetTimer(); err != nil {
@@ -244,14 +243,12 @@ func (b *BackupRestoreServer) runEtcdProbeLoopWithSnapshotter(ctx context.Contex
 						continue
 					}
 				}
-				b.logger.Infof("Shutting down...")
-				return
 			} else {
 				b.logger.Infof("Copy operation with owner %s and status %s initiated at %s as destination", copyOp.Owner, copyOp.Status, copyOp.Initiated)
-				b.logger.Infof("Sleeping for 30 seconds...")
-				time.Sleep(30 * time.Second)
-				continue
 			}
+			b.logger.Infof("Sleeping for 30 seconds...")
+			time.Sleep(30 * time.Second)
+			continue
 		}
 
 		// The decision to either take an initial delta snapshot or

--- a/pkg/server/backuprestoreserver.go
+++ b/pkg/server/backuprestoreserver.go
@@ -419,8 +419,13 @@ func (b *BackupRestoreServer) handleCopyOperationEvents(timer *time.Timer, os ob
 		select {
 		case <-timer.C:
 			b.logger.Infof("Getting copy operation...")
-			if _, copyOp, _ := copier.GetCopyOperation(os); copyOp != nil {
-				b.logger.Infof("Copy operation found, stopping snapshotter...")
+			if _, copyOp, err := copier.GetCopyOperation(os); err != nil || copyOp != nil {
+				if err != nil {
+					b.logger.Infof("Could not get copy operation: %v", err)
+				} else {
+					b.logger.Infof("Copy operation found")
+				}
+				b.logger.Infof("Stopping snapshotter...")
 				atomic.StoreUint32(&handler.AckState, HandlerAckWaiting)
 				handler.Logger.Info("Changing handler state...")
 				handler.ReqCh <- emptyStruct

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
@@ -34,6 +35,7 @@ func NewBackupRestoreComponentConfig() *BackupRestoreComponentConfig {
 		EtcdConnectionConfig:    etcdutil.NewEtcdConnectionConfig(),
 		ServerConfig:            NewHTTPServerConfig(),
 		SnapshotterConfig:       snapshotter.NewSnapshotterConfig(),
+		CopierConfig:            copier.NewConfig(),
 		SnapstoreConfig:         snapstore.NewSnapstoreConfig(),
 		RestorationConfig:       restorer.NewRestorationConfig(),
 		CompressionConfig:       compressor.NewCompressorConfig(),
@@ -46,12 +48,14 @@ func (c *BackupRestoreComponentConfig) AddFlags(fs *flag.FlagSet) {
 	c.EtcdConnectionConfig.AddFlags(fs)
 	c.ServerConfig.AddFlags(fs)
 	c.SnapshotterConfig.AddFlags(fs)
+	c.CopierConfig.AddFlags(fs)
 	c.SnapstoreConfig.AddFlags(fs)
 	c.RestorationConfig.AddFlags(fs)
 	c.CompressionConfig.AddFlags(fs)
 
 	// Miscellaneous
 	fs.StringVar(&c.DefragmentationSchedule, "defragmentation-schedule", c.DefragmentationSchedule, "schedule to defragment etcd data directory")
+	fs.BoolVar(&c.CopyBackups, "copy-backups", c.CopyBackups, "Determines whether etcd backups should be copied")
 }
 
 // Validate validates the config.
@@ -83,6 +87,7 @@ func (c *BackupRestoreComponentConfig) Validate() error {
 // Complete completes the config.
 func (c *BackupRestoreComponentConfig) Complete() {
 	c.SnapstoreConfig.Complete()
+	c.CopierConfig.CompleteWithSnapstoreConfig(c.SnapstoreConfig)
 }
 
 // HTTPServerConfig holds the server config.

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -17,6 +17,7 @@ package server
 import (
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
+	"github.com/gardener/etcd-backup-restore/pkg/snapshot/copier"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/restorer"
 	"github.com/gardener/etcd-backup-restore/pkg/snapshot/snapshotter"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
@@ -32,10 +33,12 @@ type BackupRestoreComponentConfig struct {
 	EtcdConnectionConfig    *etcdutil.EtcdConnectionConfig `json:"etcdConnectionConfig,omitempty"`
 	ServerConfig            *HTTPServerConfig              `json:"serverConfig,omitempty"`
 	SnapshotterConfig       *snapshotter.Config            `json:"snapshotterConfig,omitempty"`
+	CopierConfig            *copier.Config                 `json:"copierConfig,omitempty"`
 	SnapstoreConfig         *snapstore.Config              `json:"snapstoreConfig,omitempty"`
 	RestorationConfig       *restorer.RestorationConfig    `json:"restorationConfig,omitempty"`
 	CompressionConfig       *compressor.CompressionConfig  `json:"compressionConfig,omitempty"`
 	DefragmentationSchedule string                         `json:"defragmentationSchedule"`
+	CopyBackups             bool                           `json:"copyBackups"`
 }
 
 // latestSnapshotMetadata holds snapshot details of latest full and delta snapshots

--- a/pkg/snapshot/copier/copier.go
+++ b/pkg/snapshot/copier/copier.go
@@ -91,12 +91,12 @@ func (c *Copier) HandleCopyOperation() error {
 	}
 
 	if copyOp == nil {
-		c.logger.Info("Initializing copy operation...")
+		c.logger.Info("Initiating copy operation...")
 		obj, copyOp = InitializeCopyOperation()
 		if err := SetCopyOperation(os, obj, copyOp); err != nil {
 			return fmt.Errorf("could not set copy operation: %v", err)
 		}
-		c.logger.Info("Copy operation initialized")
+		c.logger.Info("Copy operation initiated")
 	}
 
 	if copyOp.Status == objectstore.OperationStatusDone {
@@ -106,10 +106,9 @@ func (c *Copier) HandleCopyOperation() error {
 
 	if copyOp.Status == objectstore.OperationStatusInitial {
 		c.logger.Info("Waiting for copy operation to become Ready...")
-		timer := time.NewTimer(30)
-		obj, copyOp, err = c.waitForCopyOperationReady(timer, os)
+		obj, copyOp, err = WaitForCopyOperationReady(time.NewTimer(15*time.Second), os)
 		if err != nil {
-			return fmt.Errorf("could not wait for copy operation to become ready: %v", err)
+			return fmt.Errorf("could not wait for copy operation to become Ready: %v", err)
 		}
 		c.logger.Info("Copy operation became Ready")
 	}
@@ -130,11 +129,10 @@ func (c *Copier) HandleCopyOperation() error {
 	return nil
 }
 
-func (c *Copier) waitForCopyOperationReady(timer *time.Timer, os objectstore.ObjectStore) (*objectstore.Object, *objectstore.CopyOperation, error) {
+func WaitForCopyOperationReady(timer *time.Timer, os objectstore.ObjectStore) (*objectstore.Object, *objectstore.CopyOperation, error) {
 	for {
 		select {
 		case <-timer.C:
-			c.logger.Infof("Getting copy operation...")
 			var obj *objectstore.Object
 			var copyOp *objectstore.CopyOperation
 			var err error
@@ -144,7 +142,7 @@ func (c *Copier) waitForCopyOperationReady(timer *time.Timer, os objectstore.Obj
 			if copyOp != nil && copyOp.Status == objectstore.OperationStatusReady {
 				return obj, copyOp, nil
 			}
-			timer.Reset(30 * time.Second)
+			timer.Reset(15 * time.Second)
 		}
 	}
 }

--- a/pkg/snapshot/copier/copier.go
+++ b/pkg/snapshot/copier/copier.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier
+
+import (
+	"fmt"
+
+	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewCopier returns a new copier
+func NewCopier(config *Config, snapstoreConfig *snapstore.Config, logger *logrus.Entry) *Copier {
+	return &Copier{
+		logger:                logger.WithField("actor", "snapshotter"),
+		sourceSnapstoreConfig: config.SourceSnapstore,
+		snapstoreConfig:       snapstoreConfig,
+	}
+}
+
+// Run runs the copy command
+func (c *Copier) Run() error {
+	source, err := snapstore.GetSnapstore(c.sourceSnapstoreConfig)
+	if err != nil {
+		return fmt.Errorf("Failed to get source snapstore: %v", err)
+	}
+
+	destination, err := snapstore.GetSnapstore(c.snapstoreConfig)
+	if err != nil {
+		return fmt.Errorf("Failed to get source snapstore: %v", err)
+	}
+
+	backups, err := miscellaneous.GetAllBackups(source)
+	if err != nil {
+		return fmt.Errorf("failed to get latest snapshot: %v", err)
+	}
+	if backups == nil {
+		return fmt.Errorf("No snapshot found. Will do nothing.")
+	}
+
+	for _, backup := range backups {
+		rc, err := source.Fetch(*backup.FullSnapshot)
+		if err != nil {
+			return fmt.Errorf("failed to get readerCloser form baseSnapshot")
+		}
+
+		if err := destination.Save(*backup.FullSnapshot, rc); err != nil {
+			return fmt.Errorf("failed to save snapshot to destination")
+		}
+
+		for _, deltaSnap := range backup.DeltaSnapshotList {
+			rc, err := source.Fetch(*deltaSnap)
+			if err != nil {
+				return fmt.Errorf("failed to get readerCloser form baseSnapshot")
+			}
+
+			if err := destination.Save(*deltaSnap, rc); err != nil {
+				return fmt.Errorf("failed to save snapshot to destination")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/snapshot/copier/copier.go
+++ b/pkg/snapshot/copier/copier.go
@@ -150,9 +150,6 @@ func WaitForCopyOperationReady(timer *time.Timer, os objectstore.ObjectStore) (*
 func InitializeCopyOperation() (*objectstore.Object, *objectstore.CopyOperation) {
 	now := time.Now().UTC()
 	copyOp := &objectstore.CopyOperation{
-		Source:    true,
-		Owner:     "foo",
-		Initiated: now,
 		Status:    objectstore.OperationStatusInitial,
 	}
 	obj := &objectstore.Object{

--- a/pkg/snapshot/copier/init.go
+++ b/pkg/snapshot/copier/init.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier
+
+import (
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+	flag "github.com/spf13/pflag"
+)
+
+// NewConfig returns the copier config.
+func NewConfig() *Config {
+	sourceSnapstoreConfig := snapstore.NewSnapstoreConfig()
+	sourceSnapstoreConfig.IsSource = true
+	return &Config{
+		SourceSnapstore: sourceSnapstoreConfig,
+	}
+}
+
+// AddFlags adds the flags to flagset.
+func (c *Config) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&c.SourceSnapstore.Provider, "source-storage-provider", c.SourceSnapstore.Provider, "source snapshot storage provider")
+	fs.StringVar(&c.SourceSnapstore.Container, "source-store-container", c.SourceSnapstore.Container, "source container which will be used as snapstore")
+	fs.StringVar(&c.SourceSnapstore.Prefix, "source-store-prefix", c.SourceSnapstore.Prefix, "source prefix or directory inside container under which snapstore is created")
+}
+
+// Validate validates the config.
+func (c *Config) Validate() error {
+	return nil
+}
+
+// Complete completes the config.
+func (c *Config) CompleteWithSnapstoreConfig(other *snapstore.Config) {
+	c.SourceSnapstore.CompleteWithOther(other)
+}

--- a/pkg/snapshot/copier/types.go
+++ b/pkg/snapshot/copier/types.go
@@ -22,9 +22,9 @@ import (
 
 // Copier can be used to copy backups
 type Copier struct {
-	logger                *logrus.Entry
-	sourceSnapstoreConfig *snapstore.Config
-	snapstoreConfig       *snapstore.Config
+	logger          *logrus.Entry
+	sourceSnapStore snapstore.SnapStore
+	snapStore       snapstore.SnapStore
 }
 
 // Config holds the configuration for the copier

--- a/pkg/snapshot/copier/types.go
+++ b/pkg/snapshot/copier/types.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copier
+
+import (
+	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Copier can be used to copy backups
+type Copier struct {
+	logger                *logrus.Entry
+	sourceSnapstoreConfig *snapstore.Config
+	snapstoreConfig       *snapstore.Config
+}
+
+// Config holds the configuration for the copier
+type Config struct {
+	SourceSnapstore *snapstore.Config `json:"sourceSnapstore,omitempty"`
+}

--- a/pkg/snapshot/snapshotter/garbagecollector.go
+++ b/pkg/snapshot/snapshotter/garbagecollector.go
@@ -182,7 +182,8 @@ func getSnapStreamIndexList(snapList snapstore.SnapList) []int {
 func garbageCollectChunks(store snapstore.SnapStore, snapList snapstore.SnapList, low, high int) {
 	for index := low; index < high; index++ {
 		snap := snapList[index]
-		if snap.Kind == snapstore.SnapshotKindDelta {
+		// Only delete chunk snapshots of kind Full or Object
+		if (snap.Kind != snapstore.SnapshotKindFull && snap.Kind != snapstore.SnapshotKindObject) || !snap.IsChunk {
 			continue
 		}
 		snapPath := path.Join(snap.SnapDir, snap.SnapName)

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -25,17 +25,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	cron "github.com/robfig/cron/v3"
+	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/clientv3"
+
 	"github.com/gardener/etcd-backup-restore/pkg/compressor"
 	"github.com/gardener/etcd-backup-restore/pkg/errors"
 	"github.com/gardener/etcd-backup-restore/pkg/etcdutil"
 	"github.com/gardener/etcd-backup-restore/pkg/metrics"
 	"github.com/gardener/etcd-backup-restore/pkg/miscellaneous"
-	"github.com/gardener/etcd-backup-restore/pkg/objectstore"
 	"github.com/gardener/etcd-backup-restore/pkg/snapstore"
-	"github.com/prometheus/client_golang/prometheus"
-	cron "github.com/robfig/cron/v3"
-	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/clientv3"
 )
 
 // NewSnapshotter returns the snapshotter object.
@@ -578,26 +578,3 @@ func (ssr *Snapshotter) resetFullSnapshotTimer() error {
 	return nil
 }
 
-// TODO Testing only, remove
-func (ssr *Snapshotter) writeCopyOperation(source bool) error {
-	os := objectstore.NewObjectStore(ssr.store, ssr.logger)
-
-	now := time.Now()
-	obj := &objectstore.Object{
-		Kind:      objectstore.ObjectKindCopyOperation,
-		Name:      "test",
-		CreatedOn: now,
-	}
-	copyOp := &objectstore.CopyOperation{
-		Source:    source,
-		Owner:     "foo",
-		Initiated: now,
-		Status:    objectstore.OperationStatusInitial,
-	}
-	ssr.logger.Infof("Writing object %v with contents %v...", obj, copyOp)
-	if err := os.Write(obj, copyOp); err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/pkg/snapshot/snapshotter/snapshotter.go
+++ b/pkg/snapshot/snapshotter/snapshotter.go
@@ -509,12 +509,10 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 	for {
 		select {
 		case <-ssr.fullSnapshotReqCh:
-			// TODO Testing only, remove
-			err := ssr.writeCopyOperation(true)
-			//s, err := ssr.TakeFullSnapshotAndResetTimer()
+			s, err := ssr.TakeFullSnapshotAndResetTimer()
 			res := result{
-				//Snapshot: s,
-				Err: err,
+				Snapshot: s,
+				Err:      err,
 			}
 			ssr.fullSnapshotAckCh <- res
 			if err != nil {
@@ -522,12 +520,10 @@ func (ssr *Snapshotter) snapshotEventHandler(stopCh <-chan struct{}) error {
 			}
 
 		case <-ssr.deltaSnapshotReqCh:
-			// TODO Testing only, remove
-			err := ssr.writeCopyOperation(false)
-			//s, err := ssr.takeDeltaSnapshotAndResetTimer()
+			s, err := ssr.takeDeltaSnapshotAndResetTimer()
 			res := result{
-				//Snapshot: s,
-				Err: err,
+				Snapshot: s,
+				Err:      err,
 			}
 			ssr.deltaSnapshotAckCh <- res
 			if err != nil {

--- a/pkg/snapstore/init.go
+++ b/pkg/snapstore/init.go
@@ -54,3 +54,17 @@ func (c *Config) Validate() error {
 func (c *Config) Complete() {
 	c.Prefix = path.Join(c.Prefix, backupFormatVersion)
 }
+
+// CompleteWithOther completes the config based on other config
+func (c *Config) CompleteWithOther(other *Config) {
+	if c.Provider == "" {
+		c.Provider = other.Provider
+	}
+	if c.Prefix == "" {
+		c.Prefix = other.Prefix
+	} else {
+		c.Prefix = path.Join(c.Prefix, backupFormatVersion)
+	}
+	c.MaxParallelChunkUploads = other.MaxParallelChunkUploads
+	c.TempDir = other.TempDir
+}

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -108,6 +108,8 @@ type Config struct {
 	MaxParallelChunkUploads uint `json:"maxParallelChunkUploads,omitempty"`
 	// Temporary Directory
 	TempDir string `json:"tempDir,omitempty"`
+	// IsSource determines if this SnapStore is the source for a copy operation
+	IsSource bool `json:"isSource,omitempty"`
 }
 
 type chunk struct {

--- a/pkg/snapstore/types.go
+++ b/pkg/snapstore/types.go
@@ -62,6 +62,8 @@ const (
 	SnapshotKindDelta = "Incr"
 	// SnapshotKindChunk is constant for chunk snapshot kind.
 	SnapshotKindChunk = "Chunk"
+	// SnapshotKindObject is constant for object snapshot kind.
+	SnapshotKindObject = "Object"
 
 	// chunkUploadTimeout is timeout for uploading chunk.
 	chunkUploadTimeout = 180 * time.Second

--- a/pkg/snapstore/utils.go
+++ b/pkg/snapstore/utils.go
@@ -25,14 +25,19 @@ import (
 )
 
 const (
-	envStorageContainer = "STORAGE_CONTAINER"
-	defaultLocalStore   = "default.bkp"
+	envStorageContainer       = "STORAGE_CONTAINER"
+	sourceEnvStorageContainer = "SOURCE_STORAGE_CONTAINER"
+	defaultLocalStore         = "default.bkp"
 )
 
 // GetSnapstore returns the snapstore object for give storageProvider with specified container
 func GetSnapstore(config *Config) (SnapStore, error) {
 	if config.Container == "" {
-		config.Container = os.Getenv(envStorageContainer)
+		if config.IsSource {
+			config.Container = os.Getenv(sourceEnvStorageContainer)
+		} else {
+			config.Container = os.Getenv(envStorageContainer)
+		}
 	}
 
 	if len(config.TempDir) == 0 {
@@ -72,7 +77,7 @@ func GetSnapstore(config *Config) (SnapStore, error) {
 		if config.Container == "" {
 			return nil, fmt.Errorf("storage container name not specified")
 		}
-		return NewGCSSnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads)
+		return NewGCSSnapStore(config.Container, config.Prefix, config.TempDir, config.MaxParallelChunkUploads, config.IsSource)
 	case SnapstoreProviderSwift:
 		if config.Container == "" {
 			return nil, fmt.Errorf("storage container name not specified")


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds special `Blocker` objects to simulate broker connection to the backup container.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #9
